### PR TITLE
Added get_mcp_tools and get_langchain_tools on plugins for better devx

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,22 @@ block_number = BlockNumberTool.execute(
 print(f"Current block number: {block_number}")
 
 # Use with LangChain
-from lomen.adapters.langchain import LangChainAdapter
+lc_tools = plugin.get_langchain_tools()
 
-lc_tools = [LangChainAdapter.convert(tool, plugin.credentials) 
-           for tool in plugin.tools]
-
-# Use with your LangChain agent
+# Use with your LangChain agent or LangGraph
 # agent = Agent(tools=lc_tools, ...)
+
+# Use with MCP (Model Context Protocol)
+from mcp.server.fastmcp import FastMCP
+
+# Initialize MCP server
+mcp_server = FastMCP("my_plugin")
+
+# Register tools with the MCP server
+plugin.get_mcp_tools(server=mcp_server)
+
+# Run the MCP server
+mcp_server.run(transport="stdio")  # or other transport methods
 ```
 
 ## Creating Custom Plugins

--- a/examples/langgraph/erc20_block_example.py
+++ b/examples/langgraph/erc20_block_example.py
@@ -9,7 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from dotenv import load_dotenv
 
-from lomen.adapters.langchain import LangChainAdapter
+# No need to import LangChainAdapter - we'll use the plugin's method
 from lomen.plugins.erc20 import ERC20Plugin
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph
@@ -45,7 +45,8 @@ plugin = ERC20Plugin(
     }
 )
 
-lc_tools = [LangChainAdapter.convert(tool, plugin.credentials) for tool in plugin.tools]
+# Get tools in LangChain format using the plugin's get_langchain_tools method
+lc_tools = plugin.get_langchain_tools()
 
 
 class State(TypedDict):

--- a/examples/mcp/erc20_block_example.py
+++ b/examples/mcp/erc20_block_example.py
@@ -1,98 +1,67 @@
 """
-Example of using Lomen ERC20 tools with MCP (Model Completion Protocol).
+Example of using Lomen ERC20 tools with MCP (Model Context Protocol).
 
 This example demonstrates how to:
 1. Initialize an ERC20 plugin
-2. Convert the BlockNumberTool to MCP format using the official MCP package
-3. Create an MCP server with FastAPI
+2. Use the plugin's get_mcp_tools method to register tools with MCP
+3. Create an MCP server with the FastMCP package
 4. Allow models to call the tools via the MCP protocol
 """
 
 import os
 import asyncio
+from typing import Any
 from dotenv import load_dotenv
 
 import uvicorn
-from fastapi import FastAPI
-import mcp
-from mcp.fastapi import add_routes
+from starlette.applications import Starlette
+from mcp.server.fastmcp import FastMCP
 
 from lomen.plugins.erc20 import ERC20Plugin
-from lomen.adapters.mcp import MCPAdapter
 
 # Load environment variables from .env file
 load_dotenv()
 
-# Initialize FastAPI app
-app = FastAPI(title="Lomen MCP Server")
+plugin = ERC20Plugin(
+    credentials={
+        "RPC_URL": os.environ.get("ETHEREUM_RPC_URL", "https://eth.llamarpc.com")
+    }
+)
 
-# Initialize the ERC20 plugin with credentials
-rpc_url = os.environ.get("ETHEREUM_RPC_URL", "https://eth-mainnet.alchemyapi.io/v2/your-api-key")
+# Initialize FastMCP server
+mcp_server = FastMCP("lomen")
 
-plugin = ERC20Plugin(credentials={
-    "RPC_URL": rpc_url
-})
+# Register tools with the MCP server using the plugin's get_mcp_tools method
+plugin.get_mcp_tools(server=mcp_server)
 
-# Convert tools to proper MCP Tool objects
-mcp_tools = [MCPAdapter.create_mcp_tool(tool, plugin.credentials) for tool in plugin.tools]
-
-# Create an MCP registry with our tools
-registry = mcp.Registry()
-
-# Register the tools with the MCP registry
-for tool in mcp_tools:
-    registry.register_tool(tool)
-
-# Add MCP routes to the FastAPI app
-add_routes(app, registry)
-
-# Direct tool execution example
-@app.get("/example/block-number")
-async def example_block_number():
-    """Example endpoint that directly executes the block number tool."""
-    try:
-        # Get the block number tool from the registry
-        block_number_tool = registry.get_tool("erc20_block_number")
-        if not block_number_tool:
-            return {"error": "Block number tool not found in registry"}
-            
-        # Execute the tool
-        result = await block_number_tool.function()
-        return {"success": True, "block_number": result}
-    except Exception as e:
-        return {"success": False, "error": str(e)}
-
-# Information endpoint
-@app.get("/info")
-async def info():
-    """Get information about the registered tools."""
-    tools_info = []
-    for tool_name in registry.get_tool_names():
-        tool = registry.get_tool(tool_name)
-        tools_info.append({
-            "name": tool.name,
-            "description": tool.description,
-        })
-    return {"tools": tools_info}
 
 def main():
     """Run the example code."""
-    print("\nLomen ERC20 Tool with MCP Example")
-    print("----------------------------------")
-    print("To run this example, set ETHEREUM_RPC_URL in your .env file.")
-    print(f"\nInitializing ERC20Plugin with RPC URL: {rpc_url}")
-    print("\nStarting MCP server on http://0.0.0.0:8000")
-    print("\nMCP endpoints:")
-    print("- GET /mcp/tools: Get all available tools")
-    print("- GET /mcp/tools/{tool_name}: Get information about a specific tool")
-    print("- POST /mcp/tools/{tool_name}: Execute a tool")
-    print("\nCustom endpoints:")
-    print("- GET /example/block-number: Example endpoint to get the current block number")
-    print("- GET /info: Get information about the registered tools")
-    print("\nPress Ctrl+C to stop the server")
-    
-    # Start the server
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+    print(
+        """
+            {
+                "mcpServers": {
+                    "lomen": {
+                        "command": "uv",
+                        "args": [
+                            "--directory",
+                            "REPLACE_WITH_ABSOLUTE_PATH_TO_PROJECT",
+                            "run",
+                            "examples/mcp/erc20_block_example.py"
+                        ]
+                    }
+                }
+            }
+            """
+    )
+
+    # Create and start the server with SSE transport
+    # This will start a web server that Claude Code can connect to
+
+    # Get the Starlette application
+    mcp_server.run(transport="stdio")
+
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "langchain-community>=0.3.21",
     "uvicorn>=0.34.0",
     "mcp>=1.6.0",
+    "starlette>=0.46.1",
 ]
 
 [project.urls]

--- a/src/lomen/plugins/base.py
+++ b/src/lomen/plugins/base.py
@@ -1,6 +1,6 @@
 """Base classes for Lomen plugins."""
 
-from typing import Any, Dict, List, Type
+from typing import Any, Dict, List, Type, Optional, Union
 
 from pydantic import BaseModel
 
@@ -50,3 +50,40 @@ class BasePlugin:
         ]
         if missing:
             raise ValueError(f"Missing credentials: {missing}")
+    
+    def get_langchain_tools(self):
+        """
+        Get tools in LangChain format.
+        
+        Returns a list of LangChain tools ready to use with LangChain 
+        or LangGraph frameworks.
+        
+        Returns:
+            List of LangChain tools
+        """
+        from ..adapters.langchain import LangChainAdapter
+        return [LangChainAdapter.convert(tool, self.credentials) for tool in self.tools]
+    
+    def get_mcp_tools(self, server=None):
+        """
+        Get tools in MCP format.
+        
+        If a server is provided, registers tools directly with the server.
+        Otherwise, returns a list of MCP Tool objects.
+        
+        Args:
+            server: Optional MCP server to register tools with
+            
+        Returns:
+            List of MCP Tool objects if server is None, otherwise None
+        """
+        from ..adapters.mcp import MCPAdapter
+        
+        # If server is provided, register tools directly
+        if server:
+            for tool_cls in self.tools:
+                MCPAdapter.register_with_server(tool_cls, self.credentials, server)
+            return None
+            
+        # Otherwise return MCP Tool objects
+        return [MCPAdapter.create_mcp_tool(tool, self.credentials) for tool in self.tools]

--- a/uv.lock
+++ b/uv.lock
@@ -1140,6 +1140,7 @@ dependencies = [
     { name = "mcp" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "starlette" },
     { name = "uvicorn" },
     { name = "web3" },
 ]
@@ -1162,6 +1163,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.6.0" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "starlette", specifier = ">=0.46.1" },
     { name = "uvicorn", specifier = ">=0.34.0" },
     { name = "web3" },
 ]


### PR DESCRIPTION
- Added `starlette` as a dependency in `pyproject.toml` and `uv.lock`.
- Updated examples to utilize the plugin's methods for LangChain and MCP integration, simplifying the code.
- Enhanced `MCPAdapter` to support direct tool registration with MCP servers.
- Improved documentation in examples to reflect new usage patterns and server initialization.
